### PR TITLE
Fix issue with string columnTypes + improved readme.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules

--- a/index.js
+++ b/index.js
@@ -8,16 +8,21 @@ const relationship = ({source, target, associationType, as}) => {
   if (typeString) {
     return `"${source.name}" -> "${target.name}" ${typeString}`;
   }
-}
+};
 
 const typeName = (columnType) => {
   for(let name in Sequelize.DataTypes) {
     let type = Sequelize.DataTypes[name];
+
+    if(typeof columnType === 'string') {
+        return columnType;
+      }
+
     if(columnType instanceof type && name !== 'ABSTRACT') {
       return name;
     }
   }
-}
+};
 
 const attributeTemplate = attribute => `${attribute.fieldName} :${typeName(attribute.type)}\\l\\`;
 

--- a/readme.md
+++ b/readme.md
@@ -18,9 +18,21 @@ $ npm install sequelize-erd --save-dev
 
 Exported from `sequelize-erd` is a function which takes your models. It can either take the `sequelize` instance or a path to a file to require. The function returns an svg of the models.
 
+```
+const db = new Sequelize();
+// Import DB models here
+
+const svg = sequelizeErd(db);
+writeFileSync('./erd.svg', svg);
+
+// Writes erd.svg to local path with SVG file from your Sequelize models
+```
+
 ## Use as a git hook
 
 We expose a binary for you to use as a npm script. If you want an erd diagram generated in your project folder every time you commit, add this to your package json.
+
+The source path must export your Sequelize DB instance.
 
 ```json
 {


### PR DESCRIPTION
Fixes #4 

+ Improved readme.md with usage examples
+ Fixed issue where Sequelize returns a columnType of a string instead of an object.