### PR TITLE
Fix the error due to deprecated attributes in sequelize v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const modelTemplate = ({ model, columns }) => `"${
     <tr><td bgcolor="lightblue">${model.name}</td></tr>
     ${
       columns
-        ? Object.values(model.attributes)
+        ? Object.values(model.rawAttributes)
             .map(attributeTemplate)
             .join("\n")
         : ""


### PR DESCRIPTION
When i try to use the package, i found that attributes has been deprecated in latest seuqelize v5.
So i made a change that uses rawAttributed instead of attributes, and it works perfect in sequelize v5.